### PR TITLE
Fix packaging so 1.3.18 resolves

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -21,4 +21,6 @@ dependencies:
     artifact: pro
     version: 2.8.0
 install:
-  - mvn install:install-file -Dfile=nsure.aar -DpomFile=pom.xml -Dversion=$VERSION -Dpackaging=aar
+  # Explicit coordinates, not -DpomFile: install-file generates the POM so
+  # -Dpackaging=aar reaches it. -DpomFile installs verbatim, packaging becomes jar.
+  - mvn install:install-file -Dfile=nsure.aar -DgroupId=com.nsure -DartifactId=nsure -Dversion=$VERSION -Dpackaging=aar

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
    <modelVersion>4.0.0</modelVersion>
   <groupId>com.nsure</groupId>
   <artifactId>nsure</artifactId>
+  <!-- No packaging element: Maven rejects aar here and the build fails.
+       The published POM gets it from -Dpackaging in jitpack.yml. -->
   <version>1.3.18</version>
-  <!-- Required; Maven defaults to jar and consumers then resolve a jar we never publish. -->
-  <packaging>aar</packaging>
   <dependencies>
       <dependency>
         <groupId>androidx.appcompat</groupId>


### PR DESCRIPTION
Follow-up to #12, which fails the JitPack build.

## Changes

`jitpack.yml` -- revert to the pre-1.3.15 install command. Without `-DpomFile`, `install-file` generates the published POM and `-Dpackaging=aar` reaches it.

```
-  mvn install:install-file -Dfile=nsure.aar -DpomFile=pom.xml -Dversion=$VERSION -Dpackaging=aar
+  mvn install:install-file -Dfile=nsure.aar -DgroupId=com.nsure -DartifactId=nsure -Dversion=$VERSION -Dpackaging=aar
```

`pom.xml` -- drop the `packaging` element added in #12. Maven rejects `aar` there and the build fails.
